### PR TITLE
Experimental/pagination/true photo sizes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ INCLUDES:=`pkg-config --libs $(FUSE) $(GLIB) $(FLKC) $(CURL) $(LXML) $(IMGM)`
 
 OPTS:=-mtune=native -march=native -O2 -pipe
 CFLAGS:=$(OPTS) -Wall -W -Werror -Wextra -Wconversion -Wsign-conversion -fstack-protector-strong
-LDFLAGS:=-Wl,-O1,--as-needed,-z,relro
+LDFLAGS:=-lm -Wl,-O1,--as-needed,-z,relro
 
 OBJS:=flickrms.o cache.o wget.o conf.o
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ IMGM:=MagickWand
 INCLUDES:=`pkg-config --libs $(FUSE) $(GLIB) $(FLKC) $(CURL) $(LXML) $(IMGM)`
 
 OPTS:=-mtune=native -march=native -O2 -pipe
-CFLAGS:=$(OPTS) -Wall -W -Werror -Wextra -Wconversion -Wsign-conversion -fstack-protector-strong -floop-parallelize-all -ftree-parallelize-loops=4
+CFLAGS:=$(OPTS) -Wall -W -Werror -Wextra -Wconversion -Wsign-conversion -fstack-protector-strong
 LDFLAGS:=-lm -Wl,-O1,--as-needed,-z,relro -fopenmp
 
 OBJS:=flickrms.o cache.o wget.o conf.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,8 +11,8 @@ IMGM:=MagickWand
 INCLUDES:=`pkg-config --libs $(FUSE) $(GLIB) $(FLKC) $(CURL) $(LXML) $(IMGM)`
 
 OPTS:=-mtune=native -march=native -O2 -pipe
-CFLAGS:=$(OPTS) -Wall -W -Werror -Wextra -Wconversion -Wsign-conversion -fstack-protector-strong
-LDFLAGS:=-lm -Wl,-O1,--as-needed,-z,relro
+CFLAGS:=$(OPTS) -Wall -W -Werror -Wextra -Wconversion -Wsign-conversion -fstack-protector-strong -floop-parallelize-all -ftree-parallelize-loops=4
+LDFLAGS:=-lm -Wl,-O1,--as-needed,-z,relro -fopenmp
 
 OBJS:=flickrms.o cache.o wget.o conf.o
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -330,6 +330,7 @@ static int check_photoset_cache(cached_photoset *cps) {
 
     while((fp = get_photoset_photos(cps, page++))) {
         processed = populate_photoset_cache(cps, fp);
+        flickcurl_free_photos(fp);
         if(processed < 0)
             return FAIL;
 
@@ -337,8 +338,6 @@ static int check_photoset_cache(cached_photoset *cps) {
 
         if(processed < PHOTOS_PER_API_CALL)
             break;
-
-        flickcurl_free_photos(fp);
     }
 
     cps->ci.time = time(NULL);

--- a/src/cache.h
+++ b/src/cache.h
@@ -3,9 +3,12 @@
 
 #include "common.h"
 
+#define PHOTO_SIZE_UNSET 0
+
 typedef struct {
     char *name;
     char *id;
+    char *uri;
     time_t time;
     unsigned int size;
     unsigned short dirty;

--- a/src/flickrms.c
+++ b/src/flickrms.c
@@ -21,9 +21,29 @@
 #include "wget.h"
 
 
-#define PERMISSIONS     0755
-#define TMP_DIR_NAME    ".flickrms"
-#define PHOTO_TIMEOUT   1200 /* seconds */
+#define PERMISSIONS     0755        /* Cached file permissions. */
+#define TMP_DIR_NAME    ".flickrms" /* Where to place cached photos. */
+#define PHOTO_TIMEOUT   14400       /* In seconds. */
+
+
+/* Determines whether to report the true file size in getattr before the file
+ * has been downloaded locally. The true file size will always be set and cached
+ * after a file has been downloaded (which happens when opening a file). If this
+ * option is set, Flickrms will query the remote server to get only the file
+ * size for each photo from the response headers but not download the photo.
+ * Using the true photo size is recommended for GUI applications as they tend to
+ * stat the file before opening.
+ * Using a fake file size will be much faster for command line usage.
+ */
+#define USE_TRUE_PHOTO_SIZE 1       /* 1 will use the true size. 0 will use a fake size. */
+#define FAKE_PHOTO_SIZE     1024    /* Only used when USE_TRUE_PHOTO_SIZE is set. */
+
+/* Whether to clean the temporary directory on unmount.
+ * The filesystem does not keep track of files that cannot be uploaded to Flickr,
+ * such as lock and hidden files created by file browsers, after the file system
+ * has been destroyed. This option clears the temp dir used for cached files.
+ */
+#define CLEAN_TMP_DIR_UMOUNT 1      /* 1 or 0. */
 
 
 static uid_t uid;   /* The user id of the user that mounted the filesystem */
@@ -32,8 +52,6 @@ static gid_t gid;   /* The group id of the user */
 static MagickWand *mw;
 
 static char *tmp_path;
-
-static char emptystr[] = "";
 
 
 /**
@@ -80,7 +98,7 @@ static int get_photoset_photo_from_path(const char *path, char **photoset, char 
         *photo = strdup(path_dup + i + 1);
     }
     else {
-        *photoset = strdup(emptystr);
+        *photoset = strdup("");
         *photo = strdup(path_dup);
     }
 
@@ -159,6 +177,22 @@ static inline void set_stbuf(struct stat *stbuf, mode_t mode, uid_t uid,
 }
 
 /*
+ * Get photo size if needed.
+ */
+static int process_photo(const char *photoset, const char *photo, cached_information *ci) {
+    if(USE_TRUE_PHOTO_SIZE && ci->size == PHOTO_SIZE_UNSET) {
+        int photo_size = get_url_content_length(ci->uri);
+
+        if(photo_size < 0)
+            return FAIL;
+
+        ci->size = (unsigned int)photo_size;
+        set_photo_size(photoset, photo, (unsigned int)photo_size);
+    }
+    return SUCCESS;
+}
+
+/*
  * Gets the attributes (stat) of the node at path.
  */
 static int fms_getattr(const char *path, struct stat *stbuf) {
@@ -166,26 +200,32 @@ static int fms_getattr(const char *path, struct stat *stbuf) {
     memset((void *)stbuf, 0, sizeof(struct stat));
 
     if(!strcmp(path, "/")) { /* Path is mount directory */
-        set_stbuf(stbuf, S_IFDIR | PERMISSIONS, uid, gid, 0, 0, 1); /* FIXME: Total size of all files... or leave at 0? */
+        /* FIXME: Total size of all files... or leave at 0? */
+        set_stbuf(stbuf, S_IFDIR | PERMISSIONS, uid, gid, 0, 0, 1);
         retval = SUCCESS;
     }
     else {
         cached_information *ci = NULL;
-        const char *lookup_path = path + 1;             /* Point to char after root directory */
+        /* Point to charcter after root directory */
+        const char *lookup_path = path + 1;
         unsigned short found;
         size_t index = get_slash_index(lookup_path, &found);    /* Look up first forward slash */
-        if(!found) {                                            /* If forward slash doesn't exist, we are looking at a photo without a photoset or a photoset. */
+        /* If forward slash doesn't exist, we are looking at a photo without a photoset or a photoset. */
+        if(!found) {
             if((ci = photoset_lookup(lookup_path))) {   /* See if path is to a photoset (i.e. a directory ) */
                 set_stbuf(stbuf, S_IFDIR | PERMISSIONS, uid, gid, ci->size, ci->time, 1);
                 retval = SUCCESS;
             }
-            else if((ci = photo_lookup(emptystr, lookup_path))) { /* See if path is to a photo (i.e. a file ) */
+            else if((ci = photo_lookup("", lookup_path))) { /* See if path is to a photo (i.e. a file ) */
+                process_photo("", lookup_path, ci);
                 set_stbuf(stbuf, S_IFREG | PERMISSIONS, uid, gid, ci->size, ci->time, 1);
                 retval = SUCCESS;
             }
         }
-        else {                                          /* If forward slash does exist, it means that we have a photo with a photoset (the chars before
-                                                           the slash are the photoset name and the chars after the slash are the photo name. */
+        else {
+            /* If forward slash does exist, it means that we have a photo with a photoset (the chars before
+             * the slash are the photoset name and the chars after the slash are the photo name.
+             */
             char *photoset = (char *)malloc(index + 1);
             if(!photoset)
                 retval = -ENOMEM;
@@ -195,6 +235,7 @@ static int fms_getattr(const char *path, struct stat *stbuf) {
 
                 ci = photo_lookup(photoset, lookup_path + index + 1);   /* Look for the photo */
                 if(ci) {
+                    process_photo(photoset, lookup_path + index + 1, ci);
                     set_stbuf(stbuf, S_IFREG | PERMISSIONS, uid, gid, ci->size, ci->time, 1);
                     retval = SUCCESS;
                 }
@@ -215,8 +256,8 @@ static int fms_readdir(const char *path, void *buf,
     (void)offset;
     (void)fi;
 
-    if(!strcmp(path, "/")) {                            /* Path is to mounted directory */
-        num_names = get_photo_names(emptystr, &names);  /* Get all photo names with no photoset attached */
+    if(!strcmp(path, "/")) {                      /* Path is to mounted directory */
+        num_names = get_photo_names("", &names);  /* Get all photo names with no photoset attached */
         for(i = 0; i < num_names; i++) {
             filler(buf, names[i], NULL, 0);
             free(names[i]);
@@ -298,14 +339,15 @@ static int fms_open(const char *path, struct fuse_file_info *fi) {
     set_photoset_tmp_dir(wget_path, tmp_path, photoset);
 
     uri = get_photo_uri(photoset, photo);
-    if( uri ) {
+    if(uri) {
         mkdir(wget_path, PERMISSIONS);      /* Create photoset temp directory if it doesn't exist */
 
         strcpy(wget_path, tmp_path);
         strcat(wget_path, path);
 
         if(access(wget_path, F_OK)) {
-            if(wget(uri, wget_path) < 0)  {   /* Get the image from flickr and put it into the temp dir if it doesn't already exist. */
+            /* Get the image from flickr and put it into the temp dir if it doesn't already exist. */
+            if(wget(uri, wget_path) < 0) {
                 RET(FAIL)
             }
         }
@@ -554,6 +596,9 @@ int main(int argc, char *argv[]) {
     flickr_cache_kill();
     wget_destroy();
     imagemagick_destroy();
-    remove_tmp_path();
+
+    if(CLEAN_TMP_DIR_UMOUNT)
+        remove_tmp_path();
+
     return ret;
 }

--- a/src/flickrms.c
+++ b/src/flickrms.c
@@ -180,7 +180,7 @@ static inline void set_stbuf(struct stat *stbuf, mode_t mode, uid_t uid,
  * Get photo size if needed.
  */
 static int process_photo(const char *photoset, const char *photo, cached_information *ci) {
-    if(ci->size == PHOTO_SIZE_UNSET) {
+    if(ci->size == PHOTO_SIZE_UNSET && ci->uri) {
         int photo_size = FAKE_PHOTO_SIZE;
 
         if(USE_TRUE_PHOTO_SIZE) {

--- a/src/flickrms.c
+++ b/src/flickrms.c
@@ -180,11 +180,15 @@ static inline void set_stbuf(struct stat *stbuf, mode_t mode, uid_t uid,
  * Get photo size if needed.
  */
 static int process_photo(const char *photoset, const char *photo, cached_information *ci) {
-    if(USE_TRUE_PHOTO_SIZE && ci->size == PHOTO_SIZE_UNSET) {
-        int photo_size = get_url_content_length(ci->uri);
+    if(ci->size == PHOTO_SIZE_UNSET) {
+        int photo_size = FAKE_PHOTO_SIZE;
 
-        if(photo_size < 0)
-            return FAIL;
+        if(USE_TRUE_PHOTO_SIZE) {
+            photo_size = get_url_content_length(ci->uri);
+
+            if(photo_size < 0)
+                return FAIL;
+        }
 
         ci->size = (unsigned int)photo_size;
         set_photo_size(photoset, photo, (unsigned int)photo_size);

--- a/src/wget.c
+++ b/src/wget.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <unistd.h>
 #include <curl/curl.h>
 
 #include "wget.h"
@@ -41,6 +42,7 @@ int wget(const char *in, const char *out) {
     res = curl_easy_perform(curl);  // Perform the download and write
 
     curl_easy_cleanup(curl);
+    fsync(fileno(fp));
     fclose(fp);
     return res;
 }

--- a/src/wget.c
+++ b/src/wget.c
@@ -6,20 +6,15 @@
 
 #include "wget.h"
 
-static CURL *curl_global;
 
 int wget_init() {
     if(curl_global_init(CURL_GLOBAL_ALL))
-        return FAIL;
-
-    if(!(curl_global = curl_easy_init()))
         return FAIL;
 
     return SUCCESS;
 }
 
 void wget_destroy() {
-    curl_easy_cleanup(curl_global);
     curl_global_cleanup();
 }
 
@@ -28,7 +23,7 @@ int wget(const char *in, const char *out) {
     CURLcode res;
     FILE *fp;
 
-    if(!(curl = curl_easy_duphandle(curl_global)))
+    if(!(curl = curl_easy_init()))
         return FAIL;
 
     if(!(fp = fopen(out, "wb")))    // Open in binary
@@ -62,7 +57,7 @@ int get_url_content_length(const char *url) {
     CURLcode res;
     double content_length;
 
-    if(!(curl = curl_easy_duphandle(curl_global)))
+    if(!(curl = curl_easy_init()))
         return FAIL;
 
     // Set the curl easy options

--- a/src/wget.c
+++ b/src/wget.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
-#include <string.h>
+#include <stdlib.h>
+#include <math.h>
 #include <curl/curl.h>
 
 #include "wget.h"
@@ -35,6 +36,7 @@ int wget(const char *in, const char *out) {
     // Set the curl easy options
     curl_easy_setopt(curl, CURLOPT_URL, in);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
+    //curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
     res = curl_easy_perform(curl);  // Perform the download and write
 
@@ -43,3 +45,40 @@ int wget(const char *in, const char *out) {
     return res;
 }
 
+static size_t throw_away(void *ptr, size_t size, size_t nmemb, void *data)
+{
+    (void)ptr;
+    (void)data;
+    return (size_t)(size * nmemb);
+}
+
+/* Perform a HEAD request to the url to get the Content Length from
+ * the headers. Does not get the body.
+ */
+int get_url_content_length(const char *url) {
+    CURL *curl;
+    CURLcode res;
+    double content_length;
+
+    if(!(curl = curl_easy_duphandle(curl_global)))
+        return FAIL;
+
+    // Set the curl easy options
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_NOBODY, 1); // Use HEADER request
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, throw_away);
+    curl_easy_setopt(curl, CURLOPT_HEADER, 0L);
+    //curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+
+    res = curl_easy_perform(curl);
+
+    if(res) {
+        curl_easy_cleanup(curl);
+        return FAIL;
+    }
+
+    res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &content_length);
+    curl_easy_cleanup(curl);
+
+    return (res) ? FAIL : (int)round(content_length);
+}

--- a/src/wget.h
+++ b/src/wget.h
@@ -6,5 +6,6 @@
 int wget_init();
 void wget_destroy();
 int wget(const char *in, const char *out);
+int get_url_content_length(const char *url);
 
 #endif


### PR DESCRIPTION
Addressing an issue where the photo sizes were not reported accurately before the photo had been downloaded from Flickr (which happens on open of the photo). FlickrMS will now get an accurate photo size by doing a HEAD request to the Flickr photo URL. These calls are done in a multi-threaded fashion using openMP to keep performance some what reasonable.

Fixed issue where getting all of the photos in one call was not working correctly. Using the correct pagination method to get all of the photos.

Some general cleanup of the codebase was done as well.
